### PR TITLE
Add config to disable ranking and points system

### DIFF
--- a/website/app/(default)/howto/points/page.tsx
+++ b/website/app/(default)/howto/points/page.tsx
@@ -4,6 +4,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/ui/accordion";
+import { redirect } from "next/navigation";
 
 const data = {
   "Vie du Campus": {
@@ -55,6 +56,8 @@ const data = {
 };
 
 const HowToPointsPage = () => {
+  if (process.env.DISABLE_HOWTO_POINTS) return redirect("/");
+
   return (
     <div className="px-5 lg:px-8">
       <Accordion type="single" collapsible>

--- a/website/app/(default)/ranking/page.tsx
+++ b/website/app/(default)/ranking/page.tsx
@@ -4,8 +4,11 @@ import { RefreshRankingButton } from "@/components/ranking/refreshRankingButton"
 import { db } from "@/db";
 import { hasPermission } from "@/utils/auth";
 import { headers } from "next/headers";
+import { redirect } from "next/navigation";
 
 const RankingPage = async () => {
+  if (process.env.DISABLE_RANKING_PAGE) return redirect("/");
+
   const bestPlayers = await db.query.ranking.findMany({
     limit: 3,
     orderBy: (ranking, { asc }) => [asc(ranking.rank)],

--- a/website/app/(default)/redeem/[redeemCode]/page.tsx
+++ b/website/app/(default)/redeem/[redeemCode]/page.tsx
@@ -9,6 +9,8 @@ import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 const RedeemCodePage = async (props: PageProps<"/redeem/[redeemCode]">) => {
+  if (process.env.DISABLE_EDIT_POINTS) return redirect("/");
+
   // check if the user is logged in
   const user = await auth.api.getSession({ headers: await headers() });
 

--- a/website/app/api/answers/[answerId]/route.ts
+++ b/website/app/api/answers/[answerId]/route.ts
@@ -22,6 +22,9 @@ export const POST = async (
   request: NextRequest,
   ctx: RouteContext<"/api/answers/[answerId]">
 ) => {
+  if (process.env.DISABLE_EDIT_POINTS)
+    return ApiResponse.unauthorized("Point system is currently disabled for editing");
+
   const session = await auth.api.getSession({ headers: await headers() });
 
   if (session === null) return ApiResponse.unauthorized();

--- a/website/app/api/users/[userId]/points/route.ts
+++ b/website/app/api/users/[userId]/points/route.ts
@@ -41,6 +41,11 @@ export const PUT = async (
   request: NextRequest,
   ctx: RouteContext<"/api/users/[userId]/points">
 ) => {
+  if (process.env.DISABLE_EDIT_POINTS_ADMIN)
+    return ApiResponse.unauthorized(
+      "Point system is currently disabled for editing (even for admins)"
+    );
+
   if (
     !(await hasPermission({ headers: await headers(), permissions: { points: ["add"] } }))
   )
@@ -105,6 +110,11 @@ export const DELETE = async (
   request: NextRequest,
   ctx: RouteContext<"/api/users/[userId]/points">
 ) => {
+  if (process.env.DISABLE_EDIT_POINTS_ADMIN)
+    return ApiResponse.unauthorized(
+      "Point system is currently disabled for editing (even for admins)"
+    );
+
   if (
     !(await hasPermission({ headers: await headers(), permissions: { points: ["add"] } }))
   )

--- a/website/components/home/Navbar.tsx
+++ b/website/components/home/Navbar.tsx
@@ -31,16 +31,24 @@ const Navbar = async ({ className, ...rest }: NavbarProps) => {
           } as const,
         ]
       : []),
-    {
-      name: "Comment gagner des points?",
-      variant: "secondary",
-      link: "/howto/points",
-    },
-    {
-      name: "Le Classement",
-      variant: "secondary",
-      link: "/ranking",
-    },
+    ...(!process.env.DISABLE_HOWTO_POINTS
+      ? ([
+          {
+            name: "Comment gagner des points?",
+            variant: "secondary",
+            link: "/howto/points",
+          },
+        ] as const)
+      : []),
+    ...(!process.env.DISABLE_RANKING_PAGE
+      ? ([
+          {
+            name: "Le Classement",
+            variant: "secondary",
+            link: "/ranking",
+          },
+        ] as const)
+      : []),
     ...(session
       ? ([
           { name: "Grimm Pass", variant: "secondary", link: "/pass" },


### PR DESCRIPTION
These configs are located in the `website/.env` file:

```
# prevent any edition of the points (comment to re enable it)
DISABLE_EDIT_POINTS=1

# prevent admin from editing points (comment to re enable it)
DISABLE_EDIT_POINTS_ADMIN=1

# disable the ranking page (comment to re enable it)
DISABLE_RANKING_PAGE=1

# disable how-to points (comment to re enable it)
DISABLE_HOWTO_POINTS=1
```